### PR TITLE
Fix rendering issue in Firefox with XHTML output and .innerHTML

### DIFF
--- a/datalink-to-html.xsl
+++ b/datalink-to-html.xsl
@@ -24,9 +24,7 @@ See http://creativecommons.org/publicdomain/zero/1.0/ for details.
    
     <!-- ############################################## Global behaviour -->
 
-    <xsl:output method="xml" 
-      doctype-public="-//W3C//DTD XHTML 1.0 Strict//EN"
-      doctype-system="http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd"/>
+   <xsl:output method="html" encoding="UTF-8" indent="yes"/>
 
     <!-- Don't spill the content of unknown elements. -->
     <xsl:template match="text()"/>

--- a/sodapars.js
+++ b/sodapars.js
@@ -21,13 +21,26 @@ function htmlEscape(str) {
 		.replace(/>/g, '&gt;');
 }
 
+function decodeHtmlEntities(str) {
+  const textarea = document.createElement('textarea');
+  textarea.innerHTML = str;
+  return textarea.value;
+}
+
+
 let renderTemplate = function () {
 	var _tmplCache = {};
 	let renderTemplate = function (templateId, data) {
 		var err = "";
 		var func = _tmplCache[templateId];
 		if (!func) {
-			let str = document.getElementById(templateId).innerHTML;
+			let scriptNode = document.getElementById(templateId);
+			let str = Array.from(scriptNode.childNodes)
+                            .map(node => new XMLSerializer().serializeToString(node))
+                            .join("")
+                            .replace(/[\r\t\n]/g, " ");
+
+                       str = decodeHtmlEntities(str);
 			let strFunc =
 				"let p=[],print=function(){p.push.apply(p,arguments);};"
 				+ "with(obj){p.push('"


### PR DESCRIPTION
Fix rendering issue in Firefox with XHTML output and .innerHTML

Firefox returned an empty string in this case, causing the page to render blank without errors.